### PR TITLE
Fix freeTree

### DIFF
--- a/Mining Simulator/hovMiningSimulator.cpp
+++ b/Mining Simulator/hovMiningSimulator.cpp
@@ -135,7 +135,7 @@ void displayMiningReports(Node *node){
 }
 
 void freeTree(Node *node){
-    if(node != NULL){
+    if(node == NULL){
         return;
     }
 


### PR DESCRIPTION
Check everything works fine
This inverts the conditional check which should correct the function of the `freeTree` method
```
    if(node == NULL){
        return;
    }
```